### PR TITLE
Specify RSpec's version as 2.4.x since not compatible with 3.x later

### DIFF
--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", '~> 2.14.1'
   spec.add_development_dependency "tapp"
 end


### PR DESCRIPTION
The tests of the gem have not been compatible with rspec of '~> 3.0'. 

This will fix #2 . 
