### PR TITLE
Support ruby-2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.3


### PR DESCRIPTION
Right now we're testing the gem with ruby 1.9.3 and 2.0.0 in travis-ci. ruby-2.1 series has already been out. 
