### PR TITLE
ruby2系で名前空間が干渉していたために対応をしました

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -1,3 +1,4 @@
+require 'open-uri'
 require 'faraday'
 require 'faraday_middleware'
 
@@ -15,7 +16,7 @@ module RakutenWebService
 
     def initialize(resource_class)
       @resource_class = resource_class
-      url = URI.parse(@resource_class.endpoint)
+      url = ::URI.parse(@resource_class.endpoint)
       @url = "#{url.scheme}://#{url.host}"
       @path = url.path
     end


### PR DESCRIPTION
ruby2.1.3でサンプルのコードがうごかないために対応をしました。
URI.parseがクラス内のURIとコンフリクトしているのが原因かとおもわれます。
