### PR TITLE
Webmockの仕様変更に対応したspecの修正

### DIFF
--- a/spec/rakuten_web_service/books/genre_spec.rb
+++ b/spec/rakuten_web_service/books/genre_spec.rb
@@ -24,7 +24,7 @@ describe RWS::Books::Genre do
   before do
     @expected_request = stub_request(:get, endpoint).
       with(:query => expected_query).
-      to_return(:body => expected_json)
+      to_return(:body => expected_json.to_json)
 
     RakutenWebService.configuration do |c|
       c.affiliate_id = affiliate_id
@@ -63,7 +63,7 @@ describe RWS::Books::Genre do
           :booksGenreName => 'DummyGenre',
           :genreLevel => '2'
         }
-      }.to_json
+      }
     end
 
     before do

--- a/spec/rakuten_web_service/kobo/genre_spec.rb
+++ b/spec/rakuten_web_service/kobo/genre_spec.rb
@@ -20,7 +20,7 @@ describe RWS::Kobo::Genre do
   before do
     @expected_request = stub_request(:get, endpoint).
       with(:query => expected_query).
-      to_return(:body => expected_json)
+      to_return(:body => expected_json.to_json)
 
     RakutenWebService.configuration do |c|
       c.affiliate_id = affiliate_id
@@ -41,7 +41,7 @@ describe RWS::Kobo::Genre do
   describe '#search' do
     before do
       stub_request(:get, endpoint).with(:query => expected_query).
-        to_return(:body => expected_json)
+        to_return(:body => expected_json.to_json)
     end
 
     context 'Without arguments' do


### PR DESCRIPTION
rspec によるテストを実行した際、17個のサンプルにおいて失敗しました。
実行環境: ruby 2.2.0p0, webmock 1.21.0

```
80 examples, 17 failures

Failed examples:

rspec ./spec/rakuten_web_service/books/genre_spec.rb:40 # RakutenWebService::Books::Genre.search call the endpoint once
rspec ./spec/rakuten_web_service/books/genre_spec.rb:43 # RakutenWebService::Books::Genre.search has interfaces like hash
rspec ./spec/rakuten_web_service/books/genre_spec.rb:47 # RakutenWebService::Books::Genre.search has interfaces like hash with snake case key
rspec ./spec/rakuten_web_service/books/genre_spec.rb:51 # RakutenWebService::Books::Genre.search has interfaces to get each attribute
rspec ./spec/rakuten_web_service/books/genre_spec.rb:85 # RakutenWebService::Books::Genre.root alias of constructor with the root genre id "000"
rspec ./spec/rakuten_web_service/books/genre_spec.rb:98 # RakutenWebService::Books::Genre#children When get search method are Books::Genre objects
rspec ./spec/rakuten_web_service/books/genre_spec.rb:107 # RakutenWebService::Books::Genre#children when the genre object has no children information call the endpoint to get children
rspec ./spec/rakuten_web_service/books/genre_spec.rb:124 # RakutenWebService::Books::Genre#search if the genre_id starts with "001" delegate Books::Book.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:134 # RakutenWebService::Books::Genre#search if the genre_id starts with "002" delegate Books::CD.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:144 # RakutenWebService::Books::Genre#search if the genre_id starts with "003" delegate Books::DVD.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:154 # RakutenWebService::Books::Genre#search if the genre_id starts with "004" delegate Books::Software.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:164 # RakutenWebService::Books::Genre#search if the genre_id starts with "005" delegate Books::ForeignBook.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:174 # RakutenWebService::Books::Genre#search if the genre_id starts with "006" delegate Books::Game.search
rspec ./spec/rakuten_web_service/books/genre_spec.rb:184 # RakutenWebService::Books::Genre#search if the genre_id starts with "007" delegate Books::Magazine.search
rspec ./spec/rakuten_web_service/kobo/genre_spec.rb:36 # RakutenWebService::Kobo::Genre.search call the endpoint once
rspec ./spec/rakuten_web_service/kobo/genre_spec.rb:48 # RakutenWebService::Kobo::Genre#search Without arguments should call RWS::Kobo::Ebook.search with specifying genre id
rspec ./spec/rakuten_web_service/kobo/genre_spec.rb:55 # RakutenWebService::Kobo::Genre#search With arguments should call RWS::Kobo::Ebook.search with given arguments and genre id
```

該当部分の spec ファイルを調査したところ、webmockの仕様変更により挙動が変わっていたようです（ https://github.com/bblimke/webmock/pull/427 ）。そのため、specのbefore部分でエラーが発生し、テストに通らないという事態が発生していました。

修正したので、マージをお願いします。