### PR TITLE
README に typo

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -63,7 +63,7 @@ Now rakuten\_web\_service is supporting the following APIs:
 ### Search Ichiba Items
 
 ```ruby
-  items = RakutenWebService::Ichiba::Item.search(:keyword => 'Ruby') # This returns Enamerable object
+  items = RakutenWebService::Ichiba::Item.search(:keyword => 'Ruby') # This returns Enumerable object
   items.first(10).each do |item|
     puts "#{item['itemName']}, #{item.price} yen" # You can refer to values as well as Hash.
   end

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ bundlerを利用したアプリケーションの場合、Gemfileに以下の1�
 ### 市場商品の検索
 
 ```ruby
-  items = RakutenWebService::Ichiba::Item.search(:keyword => 'Ruby') # This returns Enamerable object
+  items = RakutenWebService::Ichiba::Item.search(:keyword => 'Ruby') # This returns Enumerable object
   items.first(10).each do |item|
     puts "#{item['itemName']}, #{item.price} yen" # You can refer to values as well as Hash.
   end


### PR DESCRIPTION
README に typo がありました。
`Enamerable` → `Enumerable`

また http://webservice.rakuten.co.jp/sdk/ruby.html にも同様のtypoがありました。