### PR TITLE
Add new sub section: Prerequisites to explain how to get application id.

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -49,16 +49,23 @@ Now rakuten\_web\_service is supporting the following APIs:
 
 ## Usage
 
+### Prerequisite: Getting Application ID
+
+You need to get Application ID for your application to access to Rakuten Web Service APIs. 
+If you have not got it, register your appplication [here](https://webservice.rakuten.co.jp/app/create). 
+
 ### Configuration
 
 `RakutenWebService.configuration` allows you to specify your application's key called application\_id and your affiliate id(optional).
 
 ```ruby
   RakutenWebService.configuration do |c|
-    c.application_id = YOUR_APPLICATION_ID
-    c.affiliate_id = YOUR_AFFILIATE_ID
+    c.application_id = 'YOUR_APPLICATION_ID'
+    c.affiliate_id = 'YOUR_AFFILIATE_ID'
   end
 ```
+
+Please note that you neet to replace `'YOUR_APPLICATION_ID'` and `'YOUR_AFFILIATE_ID'` with actual ones you have.
 
 ### Search Ichiba Items
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,23 @@ bundlerを利用したアプリケーションの場合、Gemfileに以下の1�
 
 ## 使用方法
 
+### 事前準備: アプリケーションIDの取得
+
+楽天ウェブサービスAPIを利用の際に、アプリケーションIDが必要です。
+まだ取得していない場合は、楽天ウェブサービスAPIの[アプリケーション登録](https://webservice.rakuten.co.jp/app/create)を行い、アプリケーションIDを取得してください。
+
 ### 設定
 
 `RakutenWebService.configuration` メソッドを使い、Application IDとAffiliate ID（オプション）を指定することができます。
 
 ```ruby
   RakutenWebService.configuration do |c|
-    c.application_id = YOUR_APPLICATION_ID
-    c.affiliate_id = YOUR_AFFILIATE_ID
+    c.application_id = 'YOUR_APPLICATION_ID'
+    c.affiliate_id = 'YOUR_AFFILIATE_ID'
   end
 ```
+
+`'YOUR_APPLICATION_ID'` と `'YOUR_AFFILIATE_ID'` は、実際のアプリケーションIDとアフィリエイトIDに置き換えてください。
 
 ### 市場商品の検索
 


### PR DESCRIPTION
As reported #14, the current README doesn't explain about what application id is, which gets users confused. 

This PR provides new section `Prerequisites` to explain how to get new application id.