### PR TITLE
GenreBase.[] fetches and store it in repository

### DIFF
--- a/lib/rakuten_web_service/genre.rb
+++ b/lib/rakuten_web_service/genre.rb
@@ -22,7 +22,7 @@ module RakutenWebService
     def self.new(params)
       case params
       when Integer, String
-        self[params.to_s] || search(genre_id_key => params.to_s).first
+        repository[params.to_s] || search(genre_id_key => params.to_s).first
       when Hash
         super
       end
@@ -41,7 +41,7 @@ module RakutenWebService
     end
 
     def self.[](id)
-      repository[id.to_s]
+      repository[id.to_s] || new(id)
     end
 
     def self.[]=(id, genre)


### PR DESCRIPTION
As reported #15 , `RWS::Genre.[]` could not fetch genre information if it's first time for genre id to be given to the method. 

This pull request provides a patch to fix it.

@sky-oozora-bbbs Thank you for your report!