### PR TITLE
Replace the deperecated method `RWS.configuration` with `RWS.configure` in sample scripts

### DIFF
--- a/examples/books_item_search.rb
+++ b/examples/books_item_search.rb
@@ -5,7 +5,7 @@
 # If you want to search CDs dealt in Rakuten Books, you can do it with `RakutenWebService::Books::CD`. 
 # As for other resources, there are `RakutenWebService::Books::Book`, `RakutenWebService::Books::DVD` and so on. 
 # Please refer to the following documents if you want more detail of input/output parameters: 
-#   http://webservice.rakuten.co.jp/document/  
+#   http://webservice.rakuten.co.jp/document/
 #
 
 require 'rakuten_web_service'
@@ -13,7 +13,7 @@ require 'rakuten_web_service'
 application_id = ARGV.shift
 keyword = ARGV[0..-1].join(' ')
 
-RakutenWebService.configuration do |c|
+RakutenWebService.configure do |c|
   c.application_id = application_id
 end
 

--- a/examples/gora_search.rb
+++ b/examples/gora_search.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # This is a sample script f Rakuten Gora APIs.
-# RWS Ruby SDK supports Books API. The inteface is similar to ones Ichiba API.
+# RWS Ruby SDK supports Gora API. The inteface is similar to ones Ichiba API.
 # If you want to search courses dealt in Rakuten Gora, you can do it with `RakutenWebService::Gora::Course`.
 # As for other resources, there are `RakutenWebService::Gora::CourseDetail`, `RakutenWebService::Gora::Plan` and so on.
 # Please refer to the following documents if you want more detail of input/output parameters:

--- a/examples/ichiba_item_search.rb
+++ b/examples/ichiba_item_search.rb
@@ -1,11 +1,9 @@
-# encoding: utf-8
-
 require 'rakuten_web_service'
 
 application_id = ARGV.shift
 keyword = ARGV[0..-1].join(' ')
 
-RakutenWebService.configuration do |c|
+RakutenWebService.configure do |c|
   c.application_id = application_id
 end
 


### PR DESCRIPTION
In some sample scripts, the deprecated method `RWS.configuration` is still used. 
This PR replaces those with `RWS.configure`. 