### PR TITLE
Use net http instead faraday

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -1,6 +1,4 @@
 require 'uri'
-require 'faraday'
-require 'faraday_middleware'
 
 require 'rakuten_web_service/response'
 

--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -23,7 +23,7 @@ module RakutenWebService
 
     def get(params)
       params = RakutenWebService.configuration.generate_parameters(params)
-      response = connection.get(path, params)
+      response = request(path, params)
       case response.status
       when 200
         return RakutenWebService::Response.new(@resource_class, response.body)
@@ -41,6 +41,10 @@ module RakutenWebService
     end
 
     private
+    def request(path, params)
+      connection.get(path, params)
+    end
+
     def connection
       return @connection if @connection
       @connection = Faraday.new(:url => url) do |conn|

--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -47,16 +47,5 @@ module RakutenWebService
       }
       http.get(path, header)
     end
-
-    def connection
-      return @connection if @connection
-      @connection = Faraday.new(:url => url) do |conn|
-        conn.request :url_encoded
-        conn.response :json
-        conn.response :logger if RakutenWebService.configuration.debug
-        conn.adapter Faraday.default_adapter
-        conn.headers['User-Agent'] = "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])"
-      end
-    end
   end
 end

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.1.0'
 
-  spec.add_dependency 'faraday', '~> 0.9.0'
-  spec.add_dependency 'faraday_middleware'
-
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock", "~> 1.20.4"

--- a/spec/rakuten_web_service/client_spec.rb
+++ b/spec/rakuten_web_service/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Client do
-  let(:endpoint) { 'http://api.example.com/resources' }
+  let(:endpoint) { 'https://api.example.com/resources' }
   let(:resource_class) do
     double('resource_class', endpoint: endpoint)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ end
 require File.expand_path(File.join(__dir__, '..', 'lib', 'rakuten_web_service'))
 
 require 'webmock/rspec'
+require 'tapp'
 
 Dir[File.expand_path(File.join(__dir__, "support/**/*.rb"))].each { |f| require f }
 


### PR DESCRIPTION
The current version of rakuten_web_service depends only on faraday and faraday_middleware. but the gem doesn't utilise faraday. 

The pull-request gives updates for removing the dependency.