### PR TITLE
Requiring json in RWS::Client

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -1,5 +1,5 @@
 require 'uri'
-
+require 'json'
 require 'rakuten_web_service/response'
 
 module RakutenWebService

--- a/spec/support/fixture_suppot.rb
+++ b/spec/support/fixture_suppot.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module FixtureSupport
   def fixture(path)
     fixture_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'fixtures', path))


### PR DESCRIPTION
`uninitialized constant JSON` error raises when fetching items in `bundle console`. 
It's due to lack of `require 'json'` in `lib/rakuten_web_service/client.rb`. 