### PR TITLE
Define Error class

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -16,19 +16,11 @@ module RakutenWebService
       params = RakutenWebService.configuration.generate_parameters(params)
       response = request(url.path, params)
       body = JSON.parse(response.body)
-      case response.code.to_i
-      when 200
+
+      if Net::HTTPSuccess === response
         return RakutenWebService::Response.new(@resource_class, body)
-      when 400
-        raise WrongParameter, body['error_description']
-      when 404
-        raise NotFound, body['error_description']
-      when 429
-        raise TooManyRequests, body['error_description']
-      when 500
-        raise SystemError, body['error_description']
-      when 503
-        raise ServiceUnavailable, body['error_description']
+      else
+        raise RakutenWebService::Error.repository[response.code.to_i], body['error_description']
       end
     end
 

--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -1,14 +1,9 @@
 require 'uri'
 require 'json'
 require 'rakuten_web_service/response'
+require 'rakuten_web_service/error'
 
 module RakutenWebService
-  class WrongParameter < StandardError; end
-  class NotFound < StandardError; end
-  class TooManyRequests < StandardError; end
-  class SystemError < StandardError; end
-  class ServiceUnavailable < StandardError; end
-
   class Client
     attr_reader :url
 

--- a/lib/rakuten_web_service/error.rb
+++ b/lib/rakuten_web_service/error.rb
@@ -1,10 +1,28 @@
 module RakutenWebService
   class Error < StandardError
+    def self.register(status_code, error)
+      repository[status_code] = error
+    end
+
+    def self.repository
+      @repository ||= {}
+    end
   end
 
   class WrongParameter < Error; end
+  Error.register(400, WrongParameter)
+
   class NotFound < Error; end
+  Error.register(404, NotFound)
+
   class TooManyRequests < Error; end
+  Error.register(429, TooManyRequests)
+
   class SystemError < Error; end
+  Error.register(500, SystemError)
+
   class ServiceUnavailable < Error; end
+  Error.register(503, ServiceUnavailable)
 end
+
+

--- a/lib/rakuten_web_service/error.rb
+++ b/lib/rakuten_web_service/error.rb
@@ -1,0 +1,10 @@
+module RakutenWebService
+  class Error < StandardError
+  end
+
+  class WrongParameter < Error; end
+  class NotFound < Error; end
+  class TooManyRequests < Error; end
+  class SystemError < Error; end
+  class ServiceUnavailable < Error; end
+end


### PR DESCRIPTION
This pull-request provides `RakutenWebService::Error` class which is a superclass of all other error classes. 