### PR TITLE
Genre#ranking adds its genre id to given options

### DIFF
--- a/lib/rakuten_web_service/ichiba/genre.rb
+++ b/lib/rakuten_web_service/ichiba/genre.rb
@@ -12,7 +12,8 @@ module RakutenWebService
       root_id 0
 
       def ranking(options={})
-        RakutenWebService::Ichiba::RankingItem.search(:genre_id => self.id)
+        options = options.merge(genre_id: self.id)
+        RakutenWebService::Ichiba::RankingItem.search(options)
       end
 
       def products(options={})

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -153,6 +153,10 @@ describe RakutenWebService::Ichiba::Genre do
       expect(RakutenWebService::Ichiba::RankingItem).to receive(:search).with(:genre_id => genre_id)
       expect { genre.ranking }.to_not raise_error
     end
+    specify "should call RankingItem's search with genre_id and given options" do
+      expect(RakutenWebService::Ichiba::RankingItem).to receive(:search).with(genre_id: genre_id, age: 10)
+      expect { genre.ranking(age: 10) }.to_not raise_error
+    end
   end
 
   describe '#products' do


### PR DESCRIPTION
The current version of `RWS::Ichiba::Genre#ranking` ignores given options and only calls Ichiba Ranking API with its genre id. 

This pull-request provides a patch to fix the bug. 