### PR TITLE
Upgrade codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,16 @@
+engines:
+  rubocop:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - ruby
+
+ratings:
+  paths:
+    - lib/**/*.rb
+
+exclude_paths:
+  - spec/**/*
+  - examples/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: ruby
 rvm:
-- 2.1.10
-- 2.2.5
-- 2.3.1
-- ruby-head
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+  - ruby-head
+
 cache: bundler
+
 before_install:
-- gem install bundler
+  - gem install bundler
+
+script:
+  - bundle exec rake
+  - bundle exec codeclimate-test-reporter
+
 matrix:
   allow_failures:
   - rvm: ruby-head
+
 addons:
   code_climate:
     repo_token:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", '~> 1.0.0', require: nil
+  gem "codeclimate-test-reporter", '~> 1.0.0'
   gem "coveralls", require: nil
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", require: nil
+  gem "codeclimate-test-reporter", '~> 1.0.0', require: nil
   gem "coveralls", require: nil
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,4 @@
 if ENV['CI']
-  require 'codeclimate-test-reporter'
-  CodeClimate::TestReporter.start
-
   require 'coveralls'
   Coveralls.wear!
 end


### PR DESCRIPTION
The gem `codeclimate-test-reporter` has been updated to v1.0.0, which version has changes breaking its compatibility.  When built our new branch on Travis,  I saw the following error:

```
W, [2016-11-06T03:04:57.824678 #4974]  WARN -- :       This usage of the Code Climate Test Reporter is now deprecated. Since version
      1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
      run the provided `codeclimate-ruby` binary separately to report your results
      to Code Climate.
      More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md
```

This PR is to upgrade codeclimate gem. 