### PR TITLE
Raise RuntimeError if required option 'application id' is not defined. 

### DIFF
--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -12,8 +12,8 @@ module RakutenWebService
       convert_snake_key_to_camel_key(default_parameters.merge(params))
     end
 
-    def default_parameters 
-      raise if application_id.nil? || application_id == ''
+    def default_parameters
+      raise "Application ID is not defined" if application_id.nil? || application_id == ''
       { application_id: application_id, affiliate_id: affiliate_id }
     end
 

--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -13,7 +13,8 @@ module RakutenWebService
     end
 
     def default_parameters 
-      { :application_id => application_id, :affiliate_id => affiliate_id }
+      raise if application_id.nil?
+      { application_id: application_id, affiliate_id: affiliate_id }
     end
 
     def debug_mode?

--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -13,8 +13,12 @@ module RakutenWebService
     end
 
     def default_parameters
-      raise "Application ID is not defined" if application_id.nil? || application_id == ''
+      raise "Application ID is not defined" unless has_required_options?
       { application_id: application_id, affiliate_id: affiliate_id }
+    end
+
+    def has_required_options?
+      application_id && application_id != ''
     end
 
     def debug_mode?

--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -13,7 +13,7 @@ module RakutenWebService
     end
 
     def default_parameters 
-      raise if application_id.nil?
+      raise if application_id.nil? || application_id == ''
       { application_id: application_id, affiliate_id: affiliate_id }
     end
 

--- a/spec/rakuten_web_service/configuration_spec.rb
+++ b/spec/rakuten_web_service/configuration_spec.rb
@@ -102,4 +102,31 @@ describe RakutenWebService::Configuration do
       end
     end
   end
+
+  describe "#default_parameters" do
+    before do
+      RakutenWebService.configure do |c|
+        c.application_id = application_id
+      end
+    end
+
+    context "When application id is given" do
+      let(:application_id) { 'app_id' }
+
+      subject { RakutenWebService.configuration.default_parameters }
+
+      it "has application_id key and its value is a given value" do
+        expect(subject[:application_id]).to eq 'app_id'
+      end
+    end
+    context "When application id is not given" do
+      let(:application_id) { nil }
+
+      it "raises an error" do
+        expect {
+          RakutenWebService.configuration.default_parameters
+        }.to raise_error RuntimeError
+      end
+    end
+  end
 end

--- a/spec/rakuten_web_service/configuration_spec.rb
+++ b/spec/rakuten_web_service/configuration_spec.rb
@@ -125,7 +125,7 @@ describe RakutenWebService::Configuration do
       it "raises an error" do
         expect {
           RakutenWebService.configuration.default_parameters
-        }.to raise_error RuntimeError
+        }.to raise_error(RuntimeError, "Application ID is not defined")
       end
     end
     context "When application id is an empty string" do
@@ -134,7 +134,7 @@ describe RakutenWebService::Configuration do
       it "raises an error" do
         expect {
           RakutenWebService.configuration.default_parameters
-        }.to raise_error RuntimeError
+        }.to raise_error(RuntimeError, "Application ID is not defined")
       end
     end
   end

--- a/spec/rakuten_web_service/configuration_spec.rb
+++ b/spec/rakuten_web_service/configuration_spec.rb
@@ -128,5 +128,14 @@ describe RakutenWebService::Configuration do
         }.to raise_error RuntimeError
       end
     end
+    context "When application id is an empty string" do
+      let(:application_id) { '' }
+
+      it "raises an error" do
+        expect {
+          RakutenWebService.configuration.default_parameters
+        }.to raise_error RuntimeError
+      end
+    end
   end
 end


### PR DESCRIPTION
When calls RWS APIs with wrong application id or empty one, the following error appears: 

```ruby
irb(main):004:0> RWS::Ichiba::Item.search(keywrod: 'ruby').first
RakutenWebService::WrongParameter: client_id or access_token is required
```

but `client_id` or `access_token` is not defined in the documents... 😭 

This PR provides a check point to ensure application id must be defined before calling APIs. 