### PR TITLE
WrongParameter raises when giving 'sort' option.

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'cgi'
 require 'json'
 require 'rakuten_web_service/response'
 require 'rakuten_web_service/error'
@@ -28,7 +29,7 @@ module RakutenWebService
     def request(path, params)
       http = Net::HTTP.new(@url.host, @url.port)
       http.use_ssl = true
-      path = "#{path}?#{params.map { |k, v| "#{k}=#{URI.encode(v.to_s)}" }.join('&')}"
+      path = "#{path}?#{params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')}"
       header = {
         'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])"
       }

--- a/spec/rakuten_web_service/client_spec.rb
+++ b/spec/rakuten_web_service/client_spec.rb
@@ -51,6 +51,24 @@ describe RakutenWebService::Client do
         expect(@expected_request).to have_been_made.once
       end
     end
+
+    context "giving 'sort' option" do
+      let(:expected_query) do
+        {
+          applicationId: application_id,
+          affiliateId: affiliate_id,
+          sort: '+itemPrice'
+        }
+      end
+
+      before do
+        client.get(sort: '+itemPrice')
+      end
+
+      specify "encodes '+' in sort option" do
+        expect(@expected_request).to have_been_made.once
+      end
+    end
   end
 
   describe 'about exceptions' do

--- a/spec/rakuten_web_service/client_spec.rb
+++ b/spec/rakuten_web_service/client_spec.rb
@@ -57,16 +57,27 @@ describe RakutenWebService::Client do
         {
           applicationId: application_id,
           affiliateId: affiliate_id,
-          sort: '+itemPrice'
+          sort: sort_option
         }
       end
 
       before do
-        client.get(sort: '+itemPrice')
+        client.get(sort: sort_option)
       end
 
-      specify "encodes '+' in sort option" do
-        expect(@expected_request).to have_been_made.once
+      context "Specifying asceding order" do
+        let(:sort_option) { '+itemPrice' }
+
+        specify "encodes '+' in sort option" do
+          expect(@expected_request).to have_been_made.once
+        end
+      end
+      context "Specifying descending order" do
+        let(:sort_option) { '-itemPrice' }
+
+        specify "encodes '+' in sort option" do
+          expect(@expected_request).to have_been_made.once
+        end
       end
     end
   end


### PR DESCRIPTION
As reported #53, giving `sort` option such as `{sort: '+itemPrice'}` raises `WrongParameter` error.

This PR provides a patch to fix the bug. 