### PR TITLE
Debug mode

### DIFF
--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -28,6 +28,9 @@ module RakutenWebService
     def request(path, params)
       http = Net::HTTP.new(@url.host, @url.port)
       http.use_ssl = true
+      if RakutenWebService.configuration.debug_mode?
+        http.set_debug_output($stderr)
+      end
       path = "#{path}?#{params.map { |k, v| "#{k}=#{URI.encode(v.to_s)}" }.join('&')}"
       header = {
         'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])"


### PR DESCRIPTION
The gem used to support debugging HTTP conversations, meaning what request is sent and what response comes. The gem utilized `faraday`'s logging feature. So when removing the dependency on `faraday`, this debugging support got disabled. 

This PR provides that restarting HTTP debugging. 


## USAGE 

Set true as `RWS::Configuration#debug`:

```ruby
RWS.configure { |c| c.application_id ='XXXXXX'; c.debug = true }
```

After that, all HTTP responses and requests are streamed to `$stderr`. 