### PR TITLE
Notify to gitter instead of private hipchat room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ addons:
 
 notifications:
   email: false
-  hipchat:
-    rooms:
-      secure: RYuIFjh/T6Hlj9nJ0RjmlTlES+9ZWcDNe1o2KRqMdH8cK1epIEgcEzMsFP6wKPRMQqOVw6Tu5gBMltDgu26sAW8HkTnMlzYtF6AVeOgsC6VVO9XzdaoVWWQX5J/Xn21vNV1vcncuOuMByz6dmzWngZv3T0u1mcvPje00EDNo27M=
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/448544a3d5f2afca3714

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ notifications:
   email: false
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/448544a3d5f2afca3714
+      - https://webhooks.gitter.im/e/059b85fcc75550b7bc39

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Gem Version](https://badge.fury.io/rb/rakuten_web_service.svg)](https://badge.fury.io/rb/rakuten_web_service)
 [![Coverage Status](https://coveralls.io/repos/github/rakuten-ws/rws-ruby-sdk/badge.svg?branch=master)](https://coveralls.io/github/rakuten-ws/rws-ruby-sdk?branch=master)
 [![Code Climate](https://codeclimate.com/github/rakuten-ws/rws-ruby-sdk/badges/gpa.svg)](https://codeclimate.com/github/rakuten-ws/rws-ruby-sdk)
+[![Gitter](https://badges.gitter.im/rakuten-ws/rws-ruby-sdk.svg)](https://gitter.im/rakuten-ws/rws-ruby-sdk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This gem provides a client for easily accessing [Rakuten Web Service APIs](https://webservice.rakuten.co.jp/).
 


### PR DESCRIPTION
All notifications from Travis CI used to be sent to HipChat Private room only for me. I got feel it's not less transparency.  

This PR changes the destination of the notifications to Gitter for this project. 