### PR TITLE
Supported "Recipe Category Ranking" call without "category_id"

### DIFF
--- a/lib/rakuten_web_service/recipe.rb
+++ b/lib/rakuten_web_service/recipe.rb
@@ -17,8 +17,10 @@ module RakutenWebService
       response['result'].map { |r| Recipe.new(r) }
     end
 
-    def self.ranking(category)
-      self.search(category_id: category)
+    def self.ranking(category_id = nil)
+      params = {}
+      params.merge!(category_id: category_id) unless category_id.nil?
+      self.search(params)
     end
 
     class << self

--- a/spec/rakuten_web_service/recipe_spec.rb
+++ b/spec/rakuten_web_service/recipe_spec.rb
@@ -43,7 +43,7 @@ describe RakutenWebService::Recipe do
 
       expect(@expected_request).to have_been_made.once
     end
-    it 'shoudl return an array of Reciep' do
+    it 'should return an array of Recipe' do
       expect(subject).to be_all { |r| r.is_a?(RWS::Recipe) }
     end
   end

--- a/spec/rakuten_web_service/recipe_spec.rb
+++ b/spec/rakuten_web_service/recipe_spec.rb
@@ -11,6 +11,12 @@ describe RakutenWebService::Recipe do
       categoryId: category_id
     }
   end
+  let(:expected_query_without_category_id) do
+    {
+      affiliateId: affiliate_id,
+      applicationId: application_id
+    }
+  end
 
   before do
     RakutenWebService.configure do |c|
@@ -26,25 +32,48 @@ describe RakutenWebService::Recipe do
   end
 
   describe '.ranking' do
-    let(:category_id) { '30' }
+    context 'get ranking without category_id' do
+      before do
+        response = JSON.parse(fixture('recipe/ranking.json'))
 
-    before do
-      response = JSON.parse(fixture('recipe/ranking.json'))
+        @expected_request = stub_request(:get, endpoint).
+          with(query: expected_query_without_category_id).
+          to_return(body: response.to_json)
+      end
 
-      @expected_request = stub_request(:get, endpoint).
-        with(query: expected_query).
-        to_return(body: response.to_json)
+      subject { RakutenWebService::Recipe.ranking }
+
+      it 'should call search without category_id' do
+        subject.first
+
+        expect(@expected_request).to have_been_made.once
+      end
+      it 'should return an array of Recipe' do
+        expect(subject).to be_all { |r| r.is_a?(RWS::Recipe) }
+      end
     end
 
-    subject { RakutenWebService::Recipe.ranking(category_id) }
+    context 'get ranking with category_id' do
+      let(:category_id) { '30' }
 
-    it 'should call search with category id' do
-      subject.first
+      before do
+        response = JSON.parse(fixture('recipe/ranking.json'))
 
-      expect(@expected_request).to have_been_made.once
-    end
-    it 'should return an array of Recipe' do
-      expect(subject).to be_all { |r| r.is_a?(RWS::Recipe) }
+        @expected_request = stub_request(:get, endpoint).
+          with(query: expected_query).
+          to_return(body: response.to_json)
+      end
+
+      subject { RakutenWebService::Recipe.ranking(category_id) }
+
+      it 'should call search with category_id' do
+        subject.first
+
+        expect(@expected_request).to have_been_made.once
+      end
+      it 'should return an array of Recipe' do
+        expect(subject).to be_all { |r| r.is_a?(RWS::Recipe) }
+      end
     end
   end
 end


### PR DESCRIPTION
# What is this

Hi !
I found that "Recipe Category Ranking" should call without `category_id` like this.

```
$ curl -s https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20121121?applicationId=123 | jq .result[].recipeTitle
$ curl -s https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20121121?applicationId=123&categoryId=15 | jq .result[].recipeTitle
$ curl -s https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20121121?applicationId=123&categoryId=10-276 | jq .result[].recipeTitle
```

>省略時の場合は総合ランキング
https://webservice.rakuten.co.jp/api/recipecategoryranking/

![docs](https://cloud.githubusercontent.com/assets/1573290/24541929/a2f513b2-1634-11e7-8ed6-8828515ab22a.png)

So, I supported that can call method without `category_id` like this.

```
> items = RakutenWebService::Recipe.ranking
> items = RakutenWebService::Recipe.ranking('15')
> items = RakutenWebService::Recipe.ranking('10-276')
```

Please review, thanks !