### PR TITLE
Fix genre bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,16 @@
             "args": [
                 "${file}"
             ]
+        },
+        {
+            "name": "RSpec - active spec line only",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/bin/rspec",
+            "args": [
+                "${file}:${lineNumber}"
+            ]
         }
     ]
 }

--- a/lib/rakuten_web_service/ichiba/genre.rb
+++ b/lib/rakuten_web_service/ichiba/genre.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/ichiba/product'
 module RakutenWebService
   module Ichiba
     class Genre < RakutenWebService::BaseGenre
-      endpoint 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20120723'
+      endpoint 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20140222'
 
       attribute :genreId, :genreName, :genreLevel, :itemCount
 

--- a/spec/rakuten_web_service/genre_spec.rb
+++ b/spec/rakuten_web_service/genre_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+describe RakutenWebService::BaseGenre do
+  let(:dummy_endpoint) { 'https://api.example.com/dummy_genre' }
+  let(:genre_id) { "1" }
+  let(:expected_response) do
+    {
+      'current' => {
+        dummyGenreId: 1,
+        dummyGenreName: "CurrentGenre",
+        genreLevel: 2
+      },
+      'children' => [
+        {
+          dummyGenreId: 1,
+          dummyGenreName: "ChildOne",
+          genreLevel: 3
+        },
+        {
+          dummyGenreId: 2,
+          dummyGenreName: "ChildTwo",
+          genreLevel: 3
+        }
+      ],
+      'parents' => [
+        {
+          dummyGenreId: 0,
+          dummyGenreName: "TopGenre",
+          genreLevel: 1
+        }
+      ],
+      'brothers' => [
+        {
+          dummyGenreId: 3,
+          dummyGenreName: "BrotherOne",
+          genreLevel: 1
+        }
+      ]
+    }
+  end
+  let!(:genre_class) do
+
+    Class.new(RakutenWebService::BaseGenre) do
+      endpoint "https://api.example.com/dummy_genre"
+      set_resource_name 'dummy_genre'
+      root_id 0
+      attribute :dummyGenreId, :dummyGenreName, :genreLevel
+    end
+  end
+
+  let!(:expected_request) do
+    stub_request(:get, dummy_endpoint).
+      with(query: {
+        applicationId: "DUMMY_APPLICATION_ID",
+        affiliateId: "DUMMY_AFFILIATE_ID",
+        formatVersion: 2,
+        dummyGenreId: genre_id
+      }).
+      to_return(body: expected_response.to_json)
+  end
+
+  before do
+    RakutenWebService.configure do |c|
+      c.application_id = "DUMMY_APPLICATION_ID"
+      c.affiliate_id = "DUMMY_AFFILIATE_ID"
+    end
+  end
+
+  describe ".genre_id_key" do
+    it { expect(genre_class.genre_id_key).to be_eql(:dummy_genre_id) }
+  end
+
+  describe ".root_id" do
+    it { expect(genre_class.root_id).to be_eql(0) }
+  end
+
+  describe ".new" do
+    specify "should call search" do
+      genre_class.new(genre_id)
+
+      expect(expected_request).to have_been_made.once
+    end
+  end
+
+  describe ".[]" do
+    specify "should call search only once as intializing twice" do
+      2.times { genre_class[genre_id] }
+
+      expect(expected_request).to have_been_made.once
+    end
+  end
+end

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Genre do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20120723' }
+  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20140222' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:genre_id) { 0 }

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -13,14 +13,15 @@ describe RakutenWebService::Ichiba::Genre do
       genreId: genre_id
     }
   end
+  let(:fixture_file) { 'ichiba/genre_search.json' }
   let(:expected_json) do
-    JSON.parse(fixture('ichiba/genre_search.json'))
+    JSON.parse(fixture(fixture_file))
   end
 
   before do
     @expected_request = stub_request(:get, endpoint).
       with(query: expected_query).
-      to_return(body: fixture('ichiba/genre_search.json'))
+      to_return(body: fixture(fixture_file))
 
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
@@ -166,21 +167,15 @@ describe RakutenWebService::Ichiba::Genre do
   end
 
   describe "#brothers" do
-    let(:genre_id) { 559887 }
+    let(:genre_id) { 201351 }
     let(:genre) { RakutenWebService::Ichiba::Genre.new(genre_id) }
-
-    before do
-      stub_request(:get, endpoint).with(
-        query: {
-          affiliateId: affiliate_id,
-          aplicationId: application_id,
-          genreId: genre_id
-        }
-      ).to_return(body: fixture('ichiba/parents_genre_search.json'))
-    end
+    let(:fixture_file) { 'ichiba/parents_genre_search.json' }
 
     specify "should respond an array of brother Genres" do
       expect(genre.brothers).to be_a(Array)
+    end
+    specify "should have some brothers" do
+      expect(genre.brothers).to_not be_empty
     end
   end
 


### PR DESCRIPTION
It is that the version 1.5.0 or earlier of `RakutenWebService::Ichiba::Genre#brothers` always returns `[]`. It is since `brothers` is provided by the latest version 20140222 of Ichiba Genre API. 

This pull-request provides a patch to fix the bug. 