### PR TITLE
Drop ruby 2.2 from Supported Ruby Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0
@@ -27,8 +26,6 @@ matrix:
   allow_failures:
   - rvm: ruby-head
   exclude:
-  - rvm: 2.2.9
-    env: INTEGRATION=yes
   - rvm: 2.3.6
     env: INTEGRATION=yes
   - rvm: 2.4.3

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 12.3.0'


### PR DESCRIPTION
Ruby 2.2 goes to the EOL.  