### PR TITLE
Use test-reporter instead of gem ver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,6 @@ matrix:
   - rvm: ruby-head
     env: INTEGRATION=yes
 
-addons:
-  code_climate:
-    repo_token:
-      secure: Z23O936LoCDGJ/OyYsLzxTUI+CMWyrfeN1PtQdCNMdF4vxwaCsAHr3ulTdudGhKMrVZGENSEK6fq0Xal3o3oPaH9aGM9sUQ/ibRM+J94Lx6Owu4okTsIHoEy4vFeW+A/62aiwxPcoi7PFrvC8FOfaZg+b+vvYAQcitVe6qwBHiE=
-
 notifications:
   email: false
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,18 @@ group: travis_lts
 cache: bundler
 
 before_install:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - gem install bundler
 
 bundler_args:  --without vscode
 
 script:
   - bundle exec rake
-  - bundle exec codeclimate-test-reporter
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'simplecov', '~> 0.15.1', require: false
 end
 


### PR DESCRIPTION
the gem 'codeclimate-test-reporter' is deprecated. This pull-request is to replace it with alternative one. 

* [Travis CI Test Coverage](https://docs.codeclimate.com/docs/travis-ci-test-coverage)