### PR TITLE
Execute integration test once in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
   exclude:
   - rvm: 2.4.3
     env: INTEGRATION=yes
+  - rvm: 2.5.0
+    env: INTEGRATION=yes
   - rvm: ruby-head
     env: INTEGRATION=yes
 


### PR DESCRIPTION
On the PR #105, the integration test was performed twice as its configuration was wrong. 
This PR provides a cahnge to fix it.