### PR TITLE
Drop v2.4 from supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7
@@ -32,8 +31,6 @@ matrix:
   allow_failures:
   - rvm: ruby-head
   exclude:
-  - rvm: 2.4
-    env: INTEGRATION=yes
   - rvm: 2.5
     env: INTEGRATION=yes
   - rvm: 2.6

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@ English version is [here](http://github.com/rakuten-ws/rws-ruby-sdk/blob/master/
 
 ## 前提条件
 
-* Ruby 2.3 またはそれ以上のバージョンであること
+* Ruby 2.5 またはそれ以上のバージョンであること
 
 ## インストール方法
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This gem provides a client for easily accessing [Rakuten Web Service APIs](https
 
 ## Prerequisite
 
-* Ruby 2.3 or later
+* Ruby 2.5 or later
 
 ## Installation
 

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'json', '~> 2.3'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Ruby core team has announced all supports for ruby 2.4 has ended.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

According to this announce, I drop 2.4 from supported ruby version for this gem. 