### PR TITLE
add rakuten recipes api example in readme

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -138,6 +138,24 @@ Genreクラスは、`children`や`parent`といったジャンル階層を辿る
   end
 ```
 
+### レシピ
+
+```ruby
+  categories = RakutenWebService::Recipe.small_categories
+
+  # 全種類の小カテゴリーを表示
+  categories.each do |category|
+    category.name
+  end
+
+  recipes = categories.first.ranking
+
+  # カテゴリーに対応するレシピを表示
+  recipes.each do |recipe|
+    recipe.title
+  end
+```
+
 ## サポートしているAPI
 
 ### 楽天市場API

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ Genre class provides an interface to traverse sub genres.
   end
 ```
 
+### Recipe
+
+```ruby
+  categories = RakutenWebService::Recipe.small_categories
+
+  # Search all small recipe categories.
+  categories.each do |category|
+    category.name
+  end
+
+  recipes = categories.first.ranking
+
+  # Search category recipes.
+  recipes.each do |recipe|
+    recipe.title
+  end
+```
+
 ## Supported APIs
 
 Now rakuten\_web\_service is supporting the following APIs:


### PR DESCRIPTION
# 背景

レシピAPIのexample codeが存在しなかったため、READMEにコードを追加した。