### PR TITLE
Suppress deprecation warning for bundle install's option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
   - gem install bundler
-
-before_script:
   - bundle config set without 'vscode'
   - bundle config set jobs 4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ before_install:
   - ./cc-test-reporter before-build
   - gem install bundler
 
-bundler_args:  --without vscode
+before_script:
+  - bundle config set without 'vscode'
+  - bundle config set jobs 4
 
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
   - ./cc-test-reporter before-build
   - gem install bundler
   - bundle config set without 'vscode'
-  - bundle config set jobs 4
 
 script:
   - bundle exec rake

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'tapp', '~> 1.5.1'
   spec.add_development_dependency 'terminal-table', '~> 1.8.0'
-  spec.add_development_dependency 'webmock', '~> 3.8'
+  spec.add_development_dependency 'webmock', '~> 3.9'
 end


### PR DESCRIPTION
Now specifying `--without vscode` option to `bundle install` to not install gems require for developing with Visual Studio Code. But this option is deprecated. 

This PR provides changes on `.travis-ci.yml` to suppress the deprecation warning.

* [Job #1274.1 - rakuten-ws/rws-ruby-sdk - Travis CI](https://travis-ci.org/github/rakuten-ws/rws-ruby-sdk/jobs/729291818#L234)