### PR TITLE
Add rexml to dev depends to run tests in ruby 3.0

### DIFF
--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json', '~> 2.3'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rexml', '~> 3.2'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'tapp', '~> 1.5.1'
   spec.add_development_dependency 'terminal-table', '~> 1.8.0'


### PR DESCRIPTION

Now the head in ruby 3.0 always fails since rexml is no longer standard lib.
Crack does not have rexml as a dependency and the author has never merged
the PR to fix this issue:
https://github.com/jnunemaker/crack/pull/62