### PR TITLE
Fix when item can't be found by specifying elements

### DIFF
--- a/lib/rakuten_web_service/ichiba/item.rb
+++ b/lib/rakuten_web_service/ichiba/item.rb
@@ -18,7 +18,7 @@ module RakutenWebService
       endpoint 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20170706'
 
       parser do |response|
-        response['Items'].map { |item| Item.new(item) }
+        (response['Items'] || []).map { |item| Item.new(item) }
       end
 
       attribute :itemName, :catchcopy, :itemCode, :itemPrice,

--- a/spec/fixtures/ichiba/item_search_with_no_items.json
+++ b/spec/fixtures/ichiba/item_search_with_no_items.json
@@ -1,0 +1,8 @@
+{
+  "count": 0,
+  "page": 1,
+  "first": 0,
+  "last": 0,
+  "hits": 0,
+  "pageCount": 0
+}

--- a/spec/rakuten_web_service/ichiba/item_spec.rb
+++ b/spec/rakuten_web_service/ichiba/item_spec.rb
@@ -130,6 +130,19 @@ describe RakutenWebService::Ichiba::Item do
     end
   end
 
+  describe '.search(no items)' do
+    before do
+      response = JSON.parse(fixture('ichiba/item_search_with_no_items.json'))
+      @expected_request = stub_request(:get, endpoint).with(query: expected_query).to_return(body: response.to_json)
+    end
+
+    subject { RakutenWebService::Ichiba::Item.search(keyword: 'Ruby').first(1) }
+    specify '' do
+      expect { subject }.to_not raise_error
+    end
+    it { is_expected.to eq [] }
+  end
+
   describe '.all' do
     before do
       response = JSON.parse(fixture('ichiba/item_search_with_keyword_Ruby.json'))


### PR DESCRIPTION
```ruby
RWS::Ichiba::Item.search(genreId: 100317, keyword: "4fd3e6fc6e727ce7d42970b4fa00b1ce").count
# => 0

RWS::Ichiba::Item.search(genreId: 100317, keyword: "4fd3e6fc6e727ce7d42970b4fa00b1ce", elements: "itemName").count
# => /bundle/ruby/2.7.0/gems/rakuten_web_service-1.13.0/lib/rakuten_web_service/ichiba/item.rb:21:in `block in <class:Item>': undefined method `map' for nil:NilClass (NoMethodError)
```