### PR TITLE
Drop 2.5 and 2.6 from supported ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.5
-          - 2.6
           - 2.7
           - "3.0"
 

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_dependency 'json', '~> 2.3'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
2.5 has been EOL early of 2021 and 2.6 is going to be EOL next March.
In addition, I'd like to use RBS, which supports 2.7+.
This is why I drop 2.6 from the supported versions.