### PR TITLE
Add 3.1.0 to supported ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         ruby-version:
           - 2.7
           - "3.0"
+          - 3.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"rebornix.ruby",
+		"hbenl.vscode-test-explorer",
+		"connorshea.vscode-ruby-test-adapter",
+		"KoichiSasada.vscode-rdbg"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,35 +3,20 @@
     "configurations": [
         {
             "name": "Debug Local File",
-            "type": "Ruby",
+            "type": "rdbg",
             "request": "launch",
             "cwd": "${workspaceRoot}",
-            "program": "${file}"
+            "script": "${file}",
+            "useBundler": true,
+            "askParameters": true
         },
         {
-            "name": "RSpec - all",
-            "type": "Ruby",
+            "name": "Debug with RSpec - active spec line only",
+            "type": "rdbg",
             "request": "launch",
             "cwd": "${workspaceRoot}",
-            "program": "${workspaceRoot}/bin/rspec",
-            "args": [ ]
-        },
-        {
-            "name": "RSpec - active spec file only",
-            "type": "Ruby",
-            "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "program": "${workspaceRoot}/bin/rspec",
-            "args": [
-                "${file}"
-            ]
-        },
-        {
-            "name": "RSpec - active spec line only",
-            "type": "Ruby",
-            "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "program": "${workspaceRoot}/bin/rspec",
+            "script": "${workspaceRoot}/bin/rspec",
+            "useBundler": true,
             "args": [
                 "${file}:${lineNumber}"
             ]

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,3 @@ gemspec
 group :test do
   gem 'simplecov', '~> 0.17.1', require: false
 end
-
-group :vscode do
-  gem 'debase', '~> 0.2', '>= 0.2.4.1'
-  gem 'ruby-debug-ide', '~> 0.7'
-end

--- a/rakuten_web_service.gemspec
+++ b/rakuten_web_service.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json', '~> 2.3'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rexml', '~> 3.2'
   spec.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
Ruby 3.1.0 is released this Christmas! 

This PR provides the following updates

1. Add 3.1.0 to supported ruby version
2. Use debug instead of 
  debug, official debugger, is bundled in 3.1.0 and the ruby versions it supports covers the versions of this gem. 