### PR TITLE
Starting support Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           - "3.0"
           - 3.1
           - 3.2
+          - 3.3
+          - head
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 3.3 has been released in Christmas 2023 🎉  
This pull request means this gem starts supporting Ruby 3.3 💎 