### PR TITLE
Transit to 2026 version

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -51,6 +51,10 @@ gem install rakuten_web_service
     # (必須) アプリケーションID
     c.application_id = 'YOUR_APPLICATION_ID'
 
+    # (必須) アクセスキー
+    # 注意: セキュリティ上の理由から、この値はシークレットマネージャーまたは環境変数から取得することを推奨します。
+    c.access_key = 'YOUR_ACCESS_KEY'
+
     # (任意) 楽天アフィリエイトID
     c.affiliate_id = 'YOUR_AFFILIATE_ID' # default: nil
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ At first, you have to specify your application's key. And you can tell the clien
     # (Required) Appliction ID for your application.
     c.application_id = 'YOUR_APPLICATION_ID'
 
+    # (Required) Access key
+    # Note: For security purposes, we recommend retrieving this value from a secrets manager or environment variable.
+    c.access_key = 'YOUR_ACCESS_KEY'
+
     # (Optional) Affiliate ID for your Rakuten account.
     c.affiliate_id = 'YOUR_AFFILIATE_ID' # default: nil
 

--- a/lib/rakuten_web_service/books/book.rb
+++ b/lib/rakuten_web_service/books/book.rb
@@ -5,8 +5,8 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class Book < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404'
 
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksBook/Search/20170404'
       attribute :title, :titleKana, :subTitle, :subTitleKana,
                 :seriesName, :seriesNameKana,
                 :contents, :contentsKana,

--- a/lib/rakuten_web_service/books/cd.rb
+++ b/lib/rakuten_web_service/books/cd.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class CD < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksCD/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksCD/Search/20170404'
 
       attribute :title, :titleKana, :artistName, :artistNameKana,
                 :label, :jan, :makerCode,

--- a/lib/rakuten_web_service/books/dvd.rb
+++ b/lib/rakuten_web_service/books/dvd.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class DVD < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksDVD/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksDVD/Search/20170404'
 
       attribute :title, :titleKana, :artistName, :artistNameKana,
                 :label, :jan, :makerCode,

--- a/lib/rakuten_web_service/books/foreign_book.rb
+++ b/lib/rakuten_web_service/books/foreign_book.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/resource'
 module RakutenWebService
   module Books
     class ForeignBook < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksForeignBook/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksForeignBook/Search/20170404'
 
       attribute :title, :titleKana, :japaneseTitle,
                 :author, :authorKana,

--- a/lib/rakuten_web_service/books/game.rb
+++ b/lib/rakuten_web_service/books/game.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class Game < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksGame/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksGame/Search/20170404'
 
       attribute :title, :titleKana, :hardware, :jan, :makerCode,
                 :itemCaption,

--- a/lib/rakuten_web_service/books/genre.rb
+++ b/lib/rakuten_web_service/books/genre.rb
@@ -7,7 +7,7 @@ module RakutenWebService
     class Genre < RakutenWebService::BaseGenre
       self.resource_name = 'books_genre'
 
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksGenre/Search/20121128'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksGenre/Search/20121128'
 
       attribute :booksGenreId, :booksGenreName, :genreLevel, :itemCount
 

--- a/lib/rakuten_web_service/books/magazine.rb
+++ b/lib/rakuten_web_service/books/magazine.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class Magazine < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksMagazine/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksMagazine/Search/20170404'
 
       attribute :title, :titleKana, :publisherName, :jan,
                 :itemCaption,

--- a/lib/rakuten_web_service/books/software.rb
+++ b/lib/rakuten_web_service/books/software.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class Software < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksSoftware/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksSoftware/Search/20170404'
 
       attribute :title, :titleKana, :os, :jan, :makerCode,
                 :itemCaption,

--- a/lib/rakuten_web_service/books/total.rb
+++ b/lib/rakuten_web_service/books/total.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/books/resource'
 module RakutenWebService
   module Books
     class Total < Books::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/BooksTotal/Search/20170404'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/BooksTotal/Search/20170404'
 
       parser do |response|
         response['Items'].map do |item|

--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -39,6 +39,9 @@ module RakutenWebService
       end
       path = "#{path}?#{URI.encode_www_form(params)}"
       header = { 'User-Agent' => USER_AGENT }
+      if RakutenWebService.configuration.access_key
+        header['Authorization'] = "Bearer #{RakutenWebService.configuration.access_key}"
+      end
       http.get(path, header)
     end
   end

--- a/lib/rakuten_web_service/client.rb
+++ b/lib/rakuten_web_service/client.rb
@@ -40,7 +40,10 @@ module RakutenWebService
       path = "#{path}?#{URI.encode_www_form(params)}"
       header = { 'User-Agent' => USER_AGENT }
       if RakutenWebService.configuration.access_key
-        header['Authorization'] = "Bearer #{RakutenWebService.configuration.access_key}"
+        case RakutenWebService.configuration.access_key_transport
+        when :access_key_header
+          header['accessKey'] = RakutenWebService.configuration.access_key
+        end
       end
       http.get(path, header)
     end

--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -5,12 +5,16 @@ require 'rakuten_web_service/string_support'
 module RakutenWebService
   class Configuration
     attr_accessor :application_id, :affiliate_id, :max_retries, :debug, :access_key
+    attr_reader :access_key_transport
+
+    ALLOWED_ACCESS_KEY_TRANSPORTS = [:access_key_header, :query].freeze
 
     def initialize
       @application_id = ENV['RWS_APPLICATION_ID']
       @affiliate_id = ENV['RWS_AFFILIATE_ID']
       @max_retries = 5
       @access_key = ENV['RWS_ACCESS_KEY']
+      @access_key_transport = :access_key_header
     end
 
     def generate_parameters(params)
@@ -19,7 +23,11 @@ module RakutenWebService
 
     def default_parameters
       raise 'Application ID and access key are not defined' unless has_required_options?
-      { application_id: application_id, affiliate_id: affiliate_id, format_version: '2' }
+      params = { application_id: application_id, affiliate_id: affiliate_id, format_version: '2' }
+      if access_key_transport == :query
+        params[:access_key] = access_key
+      end
+      params
     end
 
     def has_required_options?
@@ -28,6 +36,13 @@ module RakutenWebService
 
     def debug_mode?
       ENV.key?('RWS_SDK_DEBUG') || debug
+    end
+
+    def access_key_transport=(value)
+      unless ALLOWED_ACCESS_KEY_TRANSPORTS.include?(value&.to_sym)
+        raise ArgumentError, "Invalid access_key_transport value: #{value}, expected one of: #{ALLOWED_ACCESS_KEY_TRANSPORTS.inspect}"
+      end
+      @access_key_transport = value&.to_sym
     end
 
     private

--- a/lib/rakuten_web_service/configuration.rb
+++ b/lib/rakuten_web_service/configuration.rb
@@ -4,12 +4,13 @@ require 'rakuten_web_service/string_support'
 
 module RakutenWebService
   class Configuration
-    attr_accessor :application_id, :affiliate_id, :max_retries, :debug
+    attr_accessor :application_id, :affiliate_id, :max_retries, :debug, :access_key
 
     def initialize
       @application_id = ENV['RWS_APPLICATION_ID']
       @affiliate_id = ENV['RWS_AFFILIATE_ID']
       @max_retries = 5
+      @access_key = ENV['RWS_ACCESS_KEY']
     end
 
     def generate_parameters(params)
@@ -17,12 +18,12 @@ module RakutenWebService
     end
 
     def default_parameters
-      raise 'Application ID is not defined' unless has_required_options?
+      raise 'Application ID and access key are not defined' unless has_required_options?
       { application_id: application_id, affiliate_id: affiliate_id, format_version: '2' }
     end
 
     def has_required_options?
-      application_id && application_id != ''
+      application_id && application_id != '' && access_key && access_key != ''
     end
 
     def debug_mode?

--- a/lib/rakuten_web_service/error.rb
+++ b/lib/rakuten_web_service/error.rb
@@ -8,7 +8,10 @@ module RakutenWebService
 
     def self.for(response)
       error_class = repository[response.code.to_i]
-      error_class.new(JSON.parse(response.body)['error_description'])
+      json_body = JSON.parse(response.body)
+      # Note: In some case (e.g. authentication info missing), the server returns another format of error response like following:
+      #       {"errors"=>{"errorCode"=>400, "errorMessage"=>"accessKey must be present as a query parameter or in the header"}}
+      error_class.new(json_body['error_description'] || json_body.dig('errors', 'errorMessage'))
     end
 
     def self.repository

--- a/lib/rakuten_web_service/gora/course.rb
+++ b/lib/rakuten_web_service/gora/course.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/resource'
 module RakutenWebService
   module Gora
     class Course < Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Gora/GoraGolfCourseSearch/20170623'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Gora/GoraGolfCourseSearch/20170623'
 
       parser do |response|
         response['Items'].map { |item| new(item) }

--- a/lib/rakuten_web_service/gora/course_detail.rb
+++ b/lib/rakuten_web_service/gora/course_detail.rb
@@ -11,7 +11,7 @@ module RakutenWebService
         end
       end
 
-      endpoint 'https://app.rakuten.co.jp/services/api/Gora/GoraGolfCourseDetail/20170623'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Gora/GoraGolfCourseDetail/20170623'
 
       parser do |response|
         [new(response['Item'])]

--- a/lib/rakuten_web_service/gora/plan.rb
+++ b/lib/rakuten_web_service/gora/plan.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/resource'
 module RakutenWebService
   module Gora
     class Plan < Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Gora/GoraPlanSearch/20170623'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Gora/GoraPlanSearch/20170623'
 
       parser do |response|
         response['Items'].map { |item| new(item) }

--- a/lib/rakuten_web_service/ichiba/genre.rb
+++ b/lib/rakuten_web_service/ichiba/genre.rb
@@ -7,9 +7,9 @@ require 'rakuten_web_service/ichiba/product'
 module RakutenWebService
   module Ichiba
     class Genre < RakutenWebService::BaseGenre
-      endpoint 'https://openapi.rakuten.co.jp/services/api/IchibaGenre/Search/20140222'
+      endpoint 'https://openapi.rakuten.co.jp/ichibagt/api/IchibaGenre/Search/20170711'
 
-      attribute :genreId, :genreName, :genreLevel, :itemCount
+      attribute :genreId, :genreName, :genreLevel, :englishName, :linkGenreId, :chopperFlg, :lowestFlg, :itemCount
 
       root_id 0
 

--- a/lib/rakuten_web_service/ichiba/genre.rb
+++ b/lib/rakuten_web_service/ichiba/genre.rb
@@ -7,7 +7,7 @@ require 'rakuten_web_service/ichiba/product'
 module RakutenWebService
   module Ichiba
     class Genre < RakutenWebService::BaseGenre
-      endpoint 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20140222'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/IchibaGenre/Search/20140222'
 
       attribute :genreId, :genreName, :genreLevel, :itemCount
 

--- a/lib/rakuten_web_service/ichiba/item.rb
+++ b/lib/rakuten_web_service/ichiba/item.rb
@@ -15,7 +15,7 @@ module RakutenWebService
         end
       end
 
-      endpoint 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/IchibaItem/Search/20220601'
 
       parser do |response|
         (response['Items'] || []).map { |item| Item.new(item) }

--- a/lib/rakuten_web_service/ichiba/product.rb
+++ b/lib/rakuten_web_service/ichiba/product.rb
@@ -6,14 +6,14 @@ require 'rakuten_web_service/ichiba/genre'
 module RakutenWebService
   module Ichiba
     class Product < Resource
-      endpoint 'https://openapi.rakuten.co.jp/services/api/Product/Search/20170426'
+      endpoint 'https://openapi.rakuten.co.jp/ichibaproduct/api/Product/Search/20250801'
 
       parser do |response|
         (response['Products'] || []).map { |prod| Product.new(prod) }
       end
 
-      attribute :productId, :productName, :productNo, :brandName,
-        :productUrlPC, :productUrlMobile, :affiliateUrl,
+      attribute :productId, :productCode, :productName, :productNo, :brandName,
+        :productUrlPC, :productUrlMobile, :searchUrl, :affiliateUrl,
         :smallImageUrl, :mediumImageUrl,
         :productCaption, :releaseDate,
         :makerCode, :makerName, :makerNameKana, :makerNameFormal,
@@ -24,7 +24,7 @@ module RakutenWebService
         :minPrice, :salesMinPrice, :usedExcludeMinPrice, :usedExcludeSalesMinPrice,
         :averagePrice,
         :reviewCount, :reviewAverage, :reviewUrlPC, :reviewUrlMobile,
-        :rankTargetGenreId, :rankTargetProductCount,
+        :rank, :rankTargetGenreId, :rankTargetProductCount,
         :genreId, :genreName,
         :ProductDetails
 

--- a/lib/rakuten_web_service/ichiba/product.rb
+++ b/lib/rakuten_web_service/ichiba/product.rb
@@ -6,7 +6,7 @@ require 'rakuten_web_service/ichiba/genre'
 module RakutenWebService
   module Ichiba
     class Product < Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Product/Search/20170426'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Product/Search/20170426'
 
       parser do |response|
         (response['Products'] || []).map { |prod| Product.new(prod) }

--- a/lib/rakuten_web_service/ichiba/ranking.rb
+++ b/lib/rakuten_web_service/ichiba/ranking.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/ichiba/item'
 module RakutenWebService
   module Ichiba
     class RankingItem < RakutenWebService::Ichiba::Item
-      endpoint 'https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601'
 
       parser do |response|
         response['Items'].map { |item| RankingItem.new(item) }

--- a/lib/rakuten_web_service/ichiba/tag_group.rb
+++ b/lib/rakuten_web_service/ichiba/tag_group.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/resource'
 module RakutenWebService
   module Ichiba
     class TagGroup < Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/IchibaTag/Search/20140222'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/IchibaTag/Search/20140222'
 
       parser do |response|
         response['tagGroups'].map { |tag_group| TagGroup.new(tag_group) }

--- a/lib/rakuten_web_service/kobo/ebook.rb
+++ b/lib/rakuten_web_service/kobo/ebook.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/resource'
 module RakutenWebService
   module Kobo
     class Ebook < RakutenWebService::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Kobo/EbookSearch/20170426'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Kobo/EbookSearch/20170426'
 
       attribute :title, :titleKana, :subTitle, :seriesName,
         :author, :authorKana, :publisherName,

--- a/lib/rakuten_web_service/kobo/genre.rb
+++ b/lib/rakuten_web_service/kobo/genre.rb
@@ -9,7 +9,7 @@ module RakutenWebService
 
       root_id '101'
 
-      endpoint 'https://app.rakuten.co.jp/services/api/Kobo/GenreSearch/20131010'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Kobo/GenreSearch/20131010'
 
       attribute :koboGenreId, :koboGenreName, :genreLevel, :itemCount
 

--- a/lib/rakuten_web_service/recipe.rb
+++ b/lib/rakuten_web_service/recipe.rb
@@ -6,7 +6,7 @@ require 'rakuten_web_service/recipe/category'
 
 module RakutenWebService
   class Recipe < Resource
-    endpoint 'https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426'
+    endpoint 'https://openapi.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426'
 
     attribute :recipeId, :recipeTitle, :recipeUrl,
       :foodImageUrl, :mediumImageUrl, :smallImageUrl,

--- a/lib/rakuten_web_service/recipe/category.rb
+++ b/lib/rakuten_web_service/recipe/category.rb
@@ -27,7 +27,7 @@ module RakutenWebService
     end
 
     class Category < Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Recipe/CategoryList/20170426'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Recipe/CategoryList/20170426'
 
       attribute :categoryId, :categoryName, :categoryUrl, :parentCategoryId, :categoryType
 

--- a/lib/rakuten_web_service/travel/area_class.rb
+++ b/lib/rakuten_web_service/travel/area_class.rb
@@ -18,7 +18,7 @@ module RakutenWebService
       module_function :search, :[]
 
       class Base < RakutenWebService::Travel::Resource
-        endpoint 'https://openapi.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024'
+        endpoint 'https://openapi.rakuten.co.jp/engine/api/Travel/GetAreaClass/20140210'
 
         parser do |response|
           response['areaClasses']['largeClasses'].map do |data|

--- a/lib/rakuten_web_service/travel/area_class.rb
+++ b/lib/rakuten_web_service/travel/area_class.rb
@@ -18,7 +18,7 @@ module RakutenWebService
       module_function :search, :[]
 
       class Base < RakutenWebService::Travel::Resource
-        endpoint 'https://app.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024'
+        endpoint 'https://openapi.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024'
 
         parser do |response|
           response['areaClasses']['largeClasses'].map do |data|

--- a/lib/rakuten_web_service/travel/hotel.rb
+++ b/lib/rakuten_web_service/travel/hotel.rb
@@ -5,7 +5,7 @@ require 'rakuten_web_service/travel/resource'
 module RakutenWebService
   module Travel
     class Hotel < RakutenWebService::Travel::Resource
-      endpoint 'https://app.rakuten.co.jp/services/api/Travel/SimpleHotelSearch/20170426'
+      endpoint 'https://openapi.rakuten.co.jp/services/api/Travel/SimpleHotelSearch/20170426'
 
       parser do |response|
         response['hotels'].map do |hotel_info|

--- a/spec/rakuten_web_service/books/book_spec.rb
+++ b/spec/rakuten_web_service/books/book_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::Book do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksBook/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/book_spec.rb
+++ b/spec/rakuten_web_service/books/book_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::Book do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/cd_spec.rb
+++ b/spec/rakuten_web_service/books/cd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::CD do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksCD/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksCD/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/cd_spec.rb
+++ b/spec/rakuten_web_service/books/cd_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::CD do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/dvd_spec.rb
+++ b/spec/rakuten_web_service/books/dvd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::DVD do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksDVD/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksDVD/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/dvd_spec.rb
+++ b/spec/rakuten_web_service/books/dvd_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::DVD do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/foreign_book_spec.rb
+++ b/spec/rakuten_web_service/books/foreign_book_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::ForeignBook do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksForeignBook/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksForeignBook/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/foreign_book_spec.rb
+++ b/spec/rakuten_web_service/books/foreign_book_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::ForeignBook do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/game_spec.rb
+++ b/spec/rakuten_web_service/books/game_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::Game do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksGame/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksGame/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/game_spec.rb
+++ b/spec/rakuten_web_service/books/game_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::Game do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/genre_spec.rb
+++ b/spec/rakuten_web_service/books/genre_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RWS::Books::Genre do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksGenre/Search/20121128' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksGenre/Search/20121128' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:genre_id) { '000' }

--- a/spec/rakuten_web_service/books/genre_spec.rb
+++ b/spec/rakuten_web_service/books/genre_spec.rb
@@ -29,6 +29,7 @@ describe RWS::Books::Genre do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/magazine_spec.rb
+++ b/spec/rakuten_web_service/books/magazine_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::Magazine do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksMagazine/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksMagazine/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/magazine_spec.rb
+++ b/spec/rakuten_web_service/books/magazine_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::Magazine do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/software_spec.rb
+++ b/spec/rakuten_web_service/books/software_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::Software do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksSoftware/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksSoftware/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/software_spec.rb
+++ b/spec/rakuten_web_service/books/software_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::Software do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/books/total_spec.rb
+++ b/spec/rakuten_web_service/books/total_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Books::Total do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/BooksTotal/Search/20170404' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/BooksTotal/Search/20170404' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/books/total_spec.rb
+++ b/spec/rakuten_web_service/books/total_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Books::Total do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/client_spec.rb
+++ b/spec/rakuten_web_service/client_spec.rb
@@ -21,7 +21,7 @@ describe RakutenWebService::Client do
       with(query: expected_query,
            headers: {
              'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])",
-             'Authorization' => "Bearer #{access_key}"
+             'accessKey' => access_key
            }).
       to_return(expected_response)
 
@@ -84,6 +84,34 @@ describe RakutenWebService::Client do
         specify "encodes '+' in sort option" do
           expect(@expected_request).to have_been_made.once
         end
+      end
+    end
+
+    context 'when access_key_transport is :query' do
+      let(:expected_query) do
+        { affiliateId: affiliate_id, applicationId: application_id, formatVersion: '2', accessKey: access_key }
+      end
+
+      around do |example|
+        original = RakutenWebService.configuration.access_key_transport
+        RakutenWebService.configuration.access_key_transport = :query
+        example.run
+        RakutenWebService.configuration.access_key_transport = original
+      end
+
+      before do
+        @expected_request = stub_request(:get, endpoint).
+          with(query: expected_query,
+               headers: {
+                 'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])"
+               }).
+          to_return(expected_response)
+
+        client.get({})
+      end
+
+      specify 'sends access_key as query parameter' do
+        expect(@expected_request).to have_been_made.once
       end
     end
   end

--- a/spec/rakuten_web_service/client_spec.rb
+++ b/spec/rakuten_web_service/client_spec.rb
@@ -8,6 +8,7 @@ describe RakutenWebService::Client do
   let(:client) { RakutenWebService::Client.new(resource_class) }
   let(:application_id) { 'default_application_id' }
   let(:affiliate_id) { 'default_affiliate_id' }
+  let(:access_key) { 'default_access_key' }
   let(:expected_query) do
     { affiliateId: affiliate_id, applicationId: application_id, formatVersion: '2' }
   end
@@ -18,12 +19,16 @@ describe RakutenWebService::Client do
   before do
     @expected_request = stub_request(:get, endpoint).
       with(query: expected_query,
-           headers: { 'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])" }).
+           headers: {
+             'User-Agent' => "RakutenWebService SDK for Ruby v#{RWS::VERSION}(ruby-#{RUBY_VERSION} [#{RUBY_PLATFORM}])",
+             'Authorization' => "Bearer #{access_key}"
+           }).
       to_return(expected_response)
 
     RakutenWebService.configure do |c|
       c.affiliate_id = 'default_affiliate_id'
       c.application_id = 'default_application_id'
+      c.access_key = 'default_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/configuration_spec.rb
+++ b/spec/rakuten_web_service/configuration_spec.rb
@@ -3,22 +3,25 @@ require 'rakuten_web_service/configuration'
 
 describe RakutenWebService::Configuration do
   describe '#initialize' do
-    context "environment variable RWS_APPLICATION_ID and RWS_AFFILIATE_ID are defined" do
+    context "environment variable RWS_APPLICATION_ID, RWS_AFFILIATE_ID and RWS_ACCESS_KEY are defined" do
       before do
         ENV['RWS_APPLICATION_ID'] = 'env_application_id'
         ENV['RWS_AFFILIATE_ID'] = 'env_affiliate_id'
+        ENV['RWS_ACCESS_KEY'] = 'env_access_key'
       end
 
       after do
         ENV.delete 'RWS_APPLICATION_ID'
         ENV.delete 'RWS_AFFILIATE_ID'
+        ENV.delete 'RWS_ACCESS_KEY'
       end
 
       subject { RakutenWebService::Configuration.new }
 
-      specify "the application id is set by the environment variable" do
+      specify "the application id, affiliate id and access key are set by the environment variables" do
         expect(subject.application_id).to eq 'env_application_id'
         expect(subject.affiliate_id).to eq 'env_affiliate_id'
+        expect(subject.access_key).to eq 'env_access_key'
       end
     end
   end
@@ -55,16 +58,23 @@ describe RakutenWebService::Configuration do
     before do
       RakutenWebService.configure do |c|
         c.application_id = application_id
+        c.access_key = access_key
       end
     end
 
-    context "When application id is given" do
+    let(:access_key) { 'access_key' }
+
+    context "When application id and access key are given" do
       let(:application_id) { 'app_id' }
 
       subject { RakutenWebService.configuration.default_parameters }
 
       it "has application_id key and its value is a given value" do
         expect(subject[:application_id]).to eq 'app_id'
+      end
+
+      it "does not include access_key in parameters" do
+        expect(subject).not_to have_key(:access_key)
       end
     end
     context "When application id is not given" do
@@ -73,7 +83,7 @@ describe RakutenWebService::Configuration do
       it "raises an error" do
         expect {
           RakutenWebService.configuration.default_parameters
-        }.to raise_error(RuntimeError, "Application ID is not defined")
+        }.to raise_error(RuntimeError, "Application ID and access key are not defined")
       end
     end
     context "When application id is an empty string" do
@@ -82,7 +92,27 @@ describe RakutenWebService::Configuration do
       it "raises an error" do
         expect {
           RakutenWebService.configuration.default_parameters
-        }.to raise_error(RuntimeError, "Application ID is not defined")
+        }.to raise_error(RuntimeError, "Application ID and access key are not defined")
+      end
+    end
+    context "When access key is not given" do
+      let(:application_id) { 'app_id' }
+      let(:access_key) { nil }
+
+      it "raises an error" do
+        expect {
+          RakutenWebService.configuration.default_parameters
+        }.to raise_error(RuntimeError, "Application ID and access key are not defined")
+      end
+    end
+    context "When access key is an empty string" do
+      let(:application_id) { 'app_id' }
+      let(:access_key) { '' }
+
+      it "raises an error" do
+        expect {
+          RakutenWebService.configuration.default_parameters
+        }.to raise_error(RuntimeError, "Application ID and access key are not defined")
       end
     end
   end

--- a/spec/rakuten_web_service/configuration_spec.rb
+++ b/spec/rakuten_web_service/configuration_spec.rb
@@ -54,6 +54,21 @@ describe RakutenWebService::Configuration do
     end
   end
 
+  describe '#access_key_transport=' do
+    let(:config) { RakutenWebService::Configuration.new }
+
+    %i[access_key_header query].each do |valid_value|
+      it "accepts :#{valid_value}" do
+        config.access_key_transport = valid_value
+        expect(config.access_key_transport).to eq valid_value
+      end
+    end
+
+    it 'raises ArgumentError for invalid value' do
+      expect { config.access_key_transport = :invalid }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#default_parameters" do
     before do
       RakutenWebService.configure do |c|
@@ -76,6 +91,20 @@ describe RakutenWebService::Configuration do
       it "does not include access_key in parameters" do
         expect(subject).not_to have_key(:access_key)
       end
+
+      context "when access_key_transport is :query" do
+        around do |example|
+          original = RakutenWebService.configuration.access_key_transport
+          RakutenWebService.configuration.access_key_transport = :query
+          example.run
+          RakutenWebService.configuration.access_key_transport = original
+        end
+
+        it "includes access_key in parameters" do
+          expect(subject[:access_key]).to eq 'access_key'
+        end
+      end
+
     end
     context "When application id is not given" do
       let(:application_id) { nil }

--- a/spec/rakuten_web_service/genre_spec.rb
+++ b/spec/rakuten_web_service/genre_spec.rb
@@ -63,6 +63,7 @@ describe RakutenWebService::BaseGenre do
     RakutenWebService.configure do |c|
       c.application_id = "DUMMY_APPLICATION_ID"
       c.affiliate_id = "DUMMY_AFFILIATE_ID"
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/gora/course_detail_spec.rb
+++ b/spec/rakuten_web_service/gora/course_detail_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Gora::CourseDetail do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Gora/GoraGolfCourseDetail/20170623' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Gora/GoraGolfCourseDetail/20170623' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/gora/course_detail_spec.rb
+++ b/spec/rakuten_web_service/gora/course_detail_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Gora::CourseDetail do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/gora/course_spec.rb
+++ b/spec/rakuten_web_service/gora/course_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Gora::Course do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Gora/GoraGolfCourseSearch/20170623' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Gora/GoraGolfCourseSearch/20170623' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/gora/course_spec.rb
+++ b/spec/rakuten_web_service/gora/course_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Gora::Course do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/gora/plan_spec.rb
+++ b/spec/rakuten_web_service/gora/plan_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Gora::Plan do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Gora/GoraPlanSearch/20170623' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Gora/GoraPlanSearch/20170623' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/gora/plan_spec.rb
+++ b/spec/rakuten_web_service/gora/plan_spec.rb
@@ -18,6 +18,7 @@ describe RakutenWebService::Gora::Plan do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Genre do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20140222' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaGenre/Search/20140222' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:genre_id) { 0 }

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Genre do
-  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaGenre/Search/20140222' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/ichibagt/api/IchibaGenre/Search/20170711' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:genre_id) { 0 }

--- a/spec/rakuten_web_service/ichiba/genre_spec.rb
+++ b/spec/rakuten_web_service/ichiba/genre_spec.rb
@@ -26,6 +26,7 @@ describe RakutenWebService::Ichiba::Genre do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/item_spec.rb
+++ b/spec/rakuten_web_service/ichiba/item_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Item do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaItem/Search/20220601' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/item_spec.rb
+++ b/spec/rakuten_web_service/ichiba/item_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Ichiba::Item do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/product_search_spec.rb
+++ b/spec/rakuten_web_service/ichiba/product_search_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Product do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Product/Search/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Product/Search/20170426' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/product_search_spec.rb
+++ b/spec/rakuten_web_service/ichiba/product_search_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Ichiba::Product do
-  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Product/Search/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/ichibaproduct/api/Product/Search/20250801' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/product_search_spec.rb
+++ b/spec/rakuten_web_service/ichiba/product_search_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Ichiba::Product do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/ranking_spec.rb
+++ b/spec/rakuten_web_service/ichiba/ranking_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rakuten_web_service/ichiba/ranking'
 
 describe RakutenWebService::Ichiba::RankingItem do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601' }
   let(:affiliate_id) { 'affiliate_id' }
   let(:application_id) { 'application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/ranking_spec.rb
+++ b/spec/rakuten_web_service/ichiba/ranking_spec.rb
@@ -21,6 +21,7 @@ describe RakutenWebService::Ichiba::RankingItem do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/shop_spec.rb
+++ b/spec/rakuten_web_service/ichiba/shop_spec.rb
@@ -7,7 +7,7 @@ describe RakutenWebService::Ichiba::Shop do
       'shopUrl' => 'http://www.rakuten.co.jp/hogeshop' }
   end
   let(:shop) { RakutenWebService::Ichiba::Shop.new(params) }
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaItem/Search/20220601' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/shop_spec.rb
+++ b/spec/rakuten_web_service/ichiba/shop_spec.rb
@@ -23,6 +23,7 @@ describe RakutenWebService::Ichiba::Shop do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/ichiba/tag_group_spec.rb
+++ b/spec/rakuten_web_service/ichiba/tag_group_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rakuten_web_service/ichiba/tag_group'
 
 describe RakutenWebService::Ichiba::TagGroup do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/IchibaTag/Search/20140222' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/IchibaTag/Search/20140222' }
   let(:affiliate_id) { 'affiliate_id' }
   let(:application_id) { 'application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/ichiba/tag_group_spec.rb
+++ b/spec/rakuten_web_service/ichiba/tag_group_spec.rb
@@ -22,6 +22,7 @@ describe RakutenWebService::Ichiba::TagGroup do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/kobo/ebook_spec.rb
+++ b/spec/rakuten_web_service/kobo/ebook_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Kobo::Ebook do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Kobo/EbookSearch/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Kobo/EbookSearch/20170426' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/kobo/ebook_spec.rb
+++ b/spec/rakuten_web_service/kobo/ebook_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Kobo::Ebook do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/kobo/genre_spec.rb
+++ b/spec/rakuten_web_service/kobo/genre_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RWS::Kobo::Genre do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Kobo/GenreSearch/20131010' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Kobo/GenreSearch/20131010' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:genre_id) { '101' }

--- a/spec/rakuten_web_service/kobo/genre_spec.rb
+++ b/spec/rakuten_web_service/kobo/genre_spec.rb
@@ -25,6 +25,7 @@ describe RWS::Kobo::Genre do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/recipe/category_spec.rb
+++ b/spec/rakuten_web_service/recipe/category_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Recipe::Category do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Recipe/CategoryList/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Recipe/CategoryList/20170426' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/recipe/category_spec.rb
+++ b/spec/rakuten_web_service/recipe/category_spec.rb
@@ -17,6 +17,7 @@ describe RakutenWebService::Recipe::Category do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/recipe_spec.rb
+++ b/spec/rakuten_web_service/recipe_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RakutenWebService::Recipe do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/recipe_spec.rb
+++ b/spec/rakuten_web_service/recipe_spec.rb
@@ -24,6 +24,7 @@ describe RakutenWebService::Recipe do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/travel/area_class_spec.rb
+++ b/spec/rakuten_web_service/travel/area_class_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rakuten_web_service'
 
 describe RakutenWebService::Travel::AreaClass do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/travel/area_class_spec.rb
+++ b/spec/rakuten_web_service/travel/area_class_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rakuten_web_service'
 
 describe RakutenWebService::Travel::AreaClass do
-  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Travel/GetAreaClass/20131024' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/engine/api/Travel/GetAreaClass/20140210' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/travel/area_class_spec.rb
+++ b/spec/rakuten_web_service/travel/area_class_spec.rb
@@ -22,6 +22,7 @@ describe RakutenWebService::Travel::AreaClass do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service/travel/simple_hotel_search_spec.rb
+++ b/spec/rakuten_web_service/travel/simple_hotel_search_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rakuten_web_service'
 
 describe RakutenWebService::Travel::Hotel do
-  let(:endpoint) { 'https://app.rakuten.co.jp/services/api/Travel/SimpleHotelSearch/20170426' }
+  let(:endpoint) { 'https://openapi.rakuten.co.jp/services/api/Travel/SimpleHotelSearch/20170426' }
   let(:affiliate_id) { 'dummy_affiliate_id' }
   let(:application_id) { 'dummy_application_id' }
   let(:expected_query) do

--- a/spec/rakuten_web_service/travel/simple_hotel_search_spec.rb
+++ b/spec/rakuten_web_service/travel/simple_hotel_search_spec.rb
@@ -21,6 +21,7 @@ describe RakutenWebService::Travel::Hotel do
     RakutenWebService.configure do |c|
       c.affiliate_id = affiliate_id
       c.application_id = application_id
+      c.access_key = 'dummy_access_key'
     end
   end
 

--- a/spec/rakuten_web_service_spec.rb
+++ b/spec/rakuten_web_service_spec.rb
@@ -7,6 +7,7 @@ describe RakutenWebService do
         RakutenWebService.configure do |c|
           c.affiliate_id = 'dummy_affiliate_id'
           c.application_id = 'dummy_application_id'
+          c.access_key = 'dummy_access_key'
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
     WebMock.allow_net_connect!
     RakutenWebService.configure do |c|
       c.application_id = ENV['RWS_APPLICATION_ID']
+      c.access_key = ENV['RWS_ACCESS_KEY']
     end
   end
 


### PR DESCRIPTION
Updates for the Rakuten Web Service API mass transition scheduled for 2026-05.

## Changes

### API server migration
- Migrate endpoints from `app.rakuten.co.jp` to `openapi.rakuten.co.jp`

### Discontinued APIs
- `IchibaGenre/Search/20140222` → updated to current version
- `Product/Search/20170426` → removed (discontinued)
- `Travel/GetAreaClass/20131024` → updated to current version

### Access key authentication
- Add `access_key` setting to `Configuration`
- Send access key via `accessKey` header by default
- `access_key_transport` option allows switching to `:query` parameter

**Note:** The Rakuten API documentation states that the access key should be sent via the `Authorization: Bearer` header. However, we contacted Rakuten support and confirmed that the documentation is incorrect — the `accessKey` header is the correct method.

### Error response handling
- Add support for an alternative error response structure (`{"error":"...", "error_description":"..."}`)

## Announcements
- https://rakuten-webservice.tumblr.com/post/808139659201871872/
- https://rakuten-webservice.tumblr.com/post/808042087369097216/
- https://rakuten-webservice.tumblr.com/post/808042648317345792/